### PR TITLE
Serve pb.js

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -30,7 +30,7 @@ func init() {
 	router.HandleFunc("/api/", createBoard).Methods("POST")
 	router.HandleFunc("/api/", listBoards).Methods("GET")
 	router.HandleFunc("/api/", methodNotAllowed)
-	router.HandleFunc("/pb.js", servePBJS).Methods("GET")
+	router.HandleFunc("/pbjs/{board}", servePBJS).Methods("GET")
 	router.HandleFunc("/{client:.*}", client).Name("client")
 	http.Handle("/", router)
 }

--- a/app/app.go
+++ b/app/app.go
@@ -30,6 +30,7 @@ func init() {
 	router.HandleFunc("/api/", createBoard).Methods("POST")
 	router.HandleFunc("/api/", listBoards).Methods("GET")
 	router.HandleFunc("/api/", methodNotAllowed)
+	router.HandleFunc("/pb.js", servePBJS).Methods("GET")
 	router.HandleFunc("/{client:.*}", client).Name("client")
 	http.Handle("/", router)
 }

--- a/app/metric.go
+++ b/app/metric.go
@@ -200,17 +200,9 @@ func getMetrics(writer http.ResponseWriter, request *http.Request) {
 
 // TODO memcache the board entity and validate boardKey against it
 func postMetric(writer http.ResponseWriter, request *http.Request) {
-	context := appengine.NewContext(request)
-
 	writer.Header().Add("Access-Control-Allow-Origin", "*")
-	writer.Header().Add(
-		"Access-Control-Allow-Methods",
-		"OPTIONS, HEAD, GET, POST, PUT, DELETE",
-	)
-	writer.Header().Add(
-		"Access-Control-Allow-Headers",
-		"Content-Type, Content-Range, Content-Disposition",
-	)
+	writer.Header().Add("Access-Control-Allow-Methods", "OPTIONS, POST")
+	writer.Header().Add("Access-Control-Allow-Headers", "Content-Type")
 
 	// Checks that the key is valid
 	encodedBoardKey := mux.Vars(request)["board"]
@@ -229,7 +221,7 @@ func postMetric(writer http.ResponseWriter, request *http.Request) {
 		Body:      string(body),
 		Timestamp: time.Now(),
 	}
-
+	context := appengine.NewContext(request)
 	post.Key, err = datastore.Put(context, datastore.NewIncompleteKey(context, PostKind, boardKey), &post)
 	if err != nil {
 		http.Error(writer, err.Error(), http.StatusBadRequest)

--- a/app/metric.go
+++ b/app/metric.go
@@ -200,6 +200,18 @@ func getMetrics(writer http.ResponseWriter, request *http.Request) {
 
 // TODO memcache the board entity and validate boardKey against it
 func postMetric(writer http.ResponseWriter, request *http.Request) {
+	context := appengine.NewContext(request)
+
+	writer.Header().Add("Access-Control-Allow-Origin", "*")
+	writer.Header().Add(
+		"Access-Control-Allow-Methods",
+		"OPTIONS, HEAD, GET, POST, PUT, DELETE",
+	)
+	writer.Header().Add(
+		"Access-Control-Allow-Headers",
+		"Content-Type, Content-Range, Content-Disposition",
+	)
+
 	// Checks that the key is valid
 	encodedBoardKey := mux.Vars(request)["board"]
 	boardKey, err := datastore.DecodeKey(encodedBoardKey)
@@ -217,7 +229,7 @@ func postMetric(writer http.ResponseWriter, request *http.Request) {
 		Body:      string(body),
 		Timestamp: time.Now(),
 	}
-	context := appengine.NewContext(request)
+
 	post.Key, err = datastore.Put(context, datastore.NewIncompleteKey(context, PostKind, boardKey), &post)
 	if err != nil {
 		http.Error(writer, err.Error(), http.StatusBadRequest)

--- a/app/pbjs.go
+++ b/app/pbjs.go
@@ -1,14 +1,12 @@
 package performanceboard
 
 import (
-    // "appengine"
+	// "appengine"
 	// "github.com/gorilla/mux"
-    "html/template"
+	"html/template"
 	"net/http"
 	"net/url"
 )
-
-
 
 func servePBJS(writer http.ResponseWriter, request *http.Request) {
 	// context := appengine.NewContext(request)
@@ -23,10 +21,10 @@ func servePBJS(writer http.ResponseWriter, request *http.Request) {
 	}
 
 	postURL := AbsURL(*url, request)
-    // context.Infof("postUrl:", postURL)
-    display_data := make(map[string]string)
+	// context.Infof("postUrl:", postURL)
+	display_data := make(map[string]string)
 	display_data["post_url"] = postURL
 
-    templates := template.Must(template.ParseFiles("static/pb.js"))
+	templates := template.Must(template.ParseFiles("static/pb.js"))
 	templates.ExecuteTemplate(writer, "pb.js", display_data)
 }

--- a/app/pbjs.go
+++ b/app/pbjs.go
@@ -1,30 +1,19 @@
 package performanceboard
 
 import (
-	// "appengine"
-	// "github.com/gorilla/mux"
+	"github.com/gorilla/mux"
 	"html/template"
 	"net/http"
-	"net/url"
 )
 
 func servePBJS(writer http.ResponseWriter, request *http.Request) {
-	// context := appengine.NewContext(request)
-
-	boardKey := request.FormValue("post_key")
-
-	boardUrl := "/api/" + boardKey
-	url, err := url.Parse(boardUrl)
-	if err != nil {
-		http.Error(writer, err.Error(), http.StatusBadRequest)
-		return
-	}
-
+	boardKey := mux.Vars(request)["board"]
+	url, _ := router.Get("board").URL("board", boardKey)
 	postURL := AbsURL(*url, request)
-	// context.Infof("postUrl:", postURL)
 	display_data := make(map[string]string)
 	display_data["post_url"] = postURL
 
 	templates := template.Must(template.ParseFiles("static/pb.js"))
 	templates.ExecuteTemplate(writer, "pb.js", display_data)
+	writer.Header().Set("content-type", "application/javascript")
 }

--- a/app/pbjs.go
+++ b/app/pbjs.go
@@ -1,0 +1,32 @@
+package performanceboard
+
+import (
+    // "appengine"
+	// "github.com/gorilla/mux"
+    "html/template"
+	"net/http"
+	"net/url"
+)
+
+
+
+func servePBJS(writer http.ResponseWriter, request *http.Request) {
+	// context := appengine.NewContext(request)
+
+	boardKey := request.FormValue("post_key")
+
+	boardUrl := "/api/" + boardKey
+	url, err := url.Parse(boardUrl)
+	if err != nil {
+		http.Error(writer, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	postURL := AbsURL(*url, request)
+    // context.Infof("postUrl:", postURL)
+    display_data := make(map[string]string)
+	display_data["post_url"] = postURL
+
+    templates := template.Must(template.ParseFiles("static/pb.js"))
+	templates.ExecuteTemplate(writer, "pb.js", display_data)
+}

--- a/app/post.go
+++ b/app/post.go
@@ -18,10 +18,8 @@ type Post struct {
 
 func getPost(writer http.ResponseWriter, request *http.Request) {
 	context := appengine.NewContext(request)
-	context.Infof("getPost")
 	encodedKey := mux.Vars(request)["post_key"]
 	postKey, err := datastore.DecodeKey(encodedKey)
-	context.Infof("looking up:%s", encodedKey)
 	if err != nil {
 		http.Error(writer, err.Error(), http.StatusBadRequest)
 		return

--- a/static/pb.js
+++ b/static/pb.js
@@ -1,0 +1,91 @@
+// <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+
+
+var PerformanceboardService = function(){
+
+    var endPoint = '{{.post_url}}';
+
+    var metrics = {};
+    var nextKey = 0;
+
+    /**
+     * Retrieves a single PDF file by keyname.
+     * @param name identifies this measurment for visualization
+     *
+     * @param key specify an active metric to attach a measurement.
+     *            pass null/undefined/false to create a root metric
+     *            a metric is stateful, so calling start repeatedly
+     *            with the same key generates a hierarchy of children
+     * @param metadata (optional) an object with metadata for this timing measurement
+     * @return the key param, or a new key if none was provided
+     */
+    var start = function(name, key, metadata) {
+        var newMetric = {
+            namespace: name,
+            start: new Date().toISOString()
+        };
+
+        if(metadata) {
+            newMetric.meta = metadata;
+        }
+
+        if(!key) {
+            key = nextKey;
+            nextKey = nextKey + 1;
+        }
+
+        if(metrics.key) {
+            metrics.key.stack.push(newMetric);
+        }
+        else {
+            metrics.key = {
+                stack: [newMetric]
+            };
+        }
+        return key;
+    };
+
+    /**
+     * Sets the stop time on a metric. Posts to the server if it's for a root measurment.
+     * @param key specify a metric to finish.
+     * @param metadata (optional) additional data to extend the metadata set on start()
+     * @return the depth of the metrics tree after this call. if zero, the
+     *         metric has been posted and the key has become invalid
+     */
+    var stop = function(key, metadata) {
+        var stack = metrics.key.stack;
+        if(!stack) {
+            return -1;
+        }
+
+        var metric = stack.pop();
+        metric.stop = new Date().toISOString();
+        if(metadata) {
+            $.extend(metric.meta, metadata);
+        }
+
+        var depth = stack.length;
+        if(depth === 0) {
+            $.ajax({
+                type: "POST",
+                url: endPoint,
+                data: metric,
+            });
+            delete metrics.key;
+        } else {
+            var parent = stack.pop();
+            if(!parent.children) {
+                parent.children = [];
+            }
+            parent.children.push(metric);
+            stack.push(parent);
+        }
+        return depth;
+    };
+
+    return {
+        start: start,
+        stop: stop
+    };
+};
+

--- a/static/pb.js
+++ b/static/pb.js
@@ -67,9 +67,12 @@ var PerformanceboardService = function(){
         var depth = stack.length;
         if(depth === 0) {
             $.ajax({
+                crossDomain: true,
                 type: "POST",
                 url: endPoint,
-                data: metric,
+                data: JSON.stringify(metric),
+                dataType: 'json',
+                complete: function(){}
             });
             delete metrics.key;
         } else {
@@ -88,4 +91,4 @@ var PerformanceboardService = function(){
         stop: stop
     };
 };
-
+window._pb = PerformanceboardService;

--- a/static/pb.js
+++ b/static/pb.js
@@ -1,7 +1,7 @@
 // <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 
 
-var PerformanceboardService = function(){
+PerformanceboardService = function(){
 
     var endPoint = '{{.post_url}}';
 
@@ -90,4 +90,3 @@ var PerformanceboardService = function(){
         stop: stop
     };
 };
-window._pb = PerformanceboardService;

--- a/static/pb.js
+++ b/static/pb.js
@@ -59,7 +59,7 @@ var PerformanceboardService = function(){
         }
 
         var metric = stack.pop();
-        metric.stop = new Date().toISOString();
+        metric.end = new Date().toISOString();
         if(metadata) {
             $.extend(metric.meta, metadata);
         }

--- a/static/pb.js
+++ b/static/pb.js
@@ -71,7 +71,6 @@ var PerformanceboardService = function(){
                 type: "POST",
                 url: endPoint,
                 data: JSON.stringify(metric),
-                dataType: 'json',
                 complete: function(){}
             });
             delete metrics.key;


### PR DESCRIPTION
This PR defines a Javascript client, an endpoint to serve it, and adds CORS headers for data POST'd by a client running that code.

Tested in Chrome and Firefox.

@mgbelisle 
