### PR TITLE
Strip ancestors

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -10,14 +10,15 @@ indexes:
 # automatically uploaded to the admin console when you next deploy
 # your application using appcfg.py.
 
-- kind: Metric
+- kind: AggregateMetric
   properties:
+  - name: BinType
   - name: BoardKey
   - name: Namespace
-  - name: Start
+  - name: StartTime
     direction: desc
 
-- kind: Taxonomy
+- kind: Metric
   properties:
   - name: BoardKey
   - name: Namespace

--- a/index.yaml
+++ b/index.yaml
@@ -10,17 +10,9 @@ indexes:
 # automatically uploaded to the admin console when you next deploy
 # your application using appcfg.py.
 
-- kind: AggregateMetric
-  ancestor: yes
-  properties:
-  - name: BinType
-  - name: Namespace
-  - name: StartTime
-    direction: desc
-
 - kind: Metric
-  ancestor: yes
   properties:
+  - name: BoardKey
   - name: Namespace
   - name: Start
     direction: desc

--- a/server/aggregate.go
+++ b/server/aggregate.go
@@ -78,7 +78,7 @@ func readAggregates(context appengine.Context,
 // HTTP handlers
 
 func getAggregates(writer http.ResponseWriter, request *http.Request) {
-	
+
 	log.Println("readAggregates request:", request)
 
 	context := appengine.NewContext(request)

--- a/server/aggregate.go
+++ b/server/aggregate.go
@@ -25,7 +25,7 @@ func makeAggregateDtoList(metrics []AggregateMetric) []JsonResponse {
 }
 
 func readAggregates(context appengine.Context,
-	boardKey *datastore.Key, namespace string, binType string,
+	boardKeyString string, namespace string, binType string,
 	newestTime time.Time, duration time.Duration,
 	limit int, cursor string) ([]AggregateMetric, string, error) {
 	// newestTime: same as 'end'
@@ -33,7 +33,7 @@ func readAggregates(context appengine.Context,
 	// binTypes: "day", "hour", "minute", or "second"
 
 	q := datastore.NewQuery(AggregateMetricKind).
-		Filter("BoardKey =", boardKey).
+		Filter("BoardKey =", boardKeyString).
 		Filter("Namespace =", namespace).
 		Filter("BinType =", binType).
 		Filter("StartTime <=", newestTime).
@@ -83,15 +83,11 @@ func getAggregates(writer http.ResponseWriter, request *http.Request) {
 
 	context := appengine.NewContext(request)
 	encodedKey := mux.Vars(request)["board"]
-	boardKey, err := datastore.DecodeKey(encodedKey)
-	if err != nil {
-		http.Error(writer, err.Error(), http.StatusBadRequest)
-		return
-	}
 	namespace := mux.Vars(request)["namespace"]
 	binType := mux.Vars(request)["bin_type"] // day, hour, minute, second
 
 	end := time.Now()
+	err := error(nil)
 
 	// parse optional end time
 	if endParam := request.FormValue("end"); len(endParam) > 0 {
@@ -131,7 +127,7 @@ func getAggregates(writer http.ResponseWriter, request *http.Request) {
 	cursor := request.FormValue("cursor")
 
 	// read aggregates
-	aggregates, cursor, err := readAggregates(context, boardKey, namespace, binType, end, duration, limit, cursor)
+	aggregates, cursor, err := readAggregates(context, encodedKey, namespace, binType, end, duration, limit, cursor)
 	if err != nil {
 		http.Error(writer, err.Error(), http.StatusBadRequest)
 		return

--- a/server/aggregate.go
+++ b/server/aggregate.go
@@ -4,6 +4,7 @@ import (
 	"appengine"
 	"appengine/datastore"
 	"github.com/gorilla/mux"
+	"log"
 	"net/http"
 	"strconv"
 	"time"
@@ -32,11 +33,11 @@ func readAggregates(context appengine.Context,
 	// binTypes: "day", "hour", "minute", or "second"
 
 	q := datastore.NewQuery(AggregateMetricKind).
+		Filter("BoardKey =", boardKey).
 		Filter("Namespace =", namespace).
 		Filter("BinType =", binType).
 		Filter("StartTime <=", newestTime).
-		Order("-StartTime").
-		Ancestor(boardKey)
+		Order("-StartTime")
 
 	if duration > 0 {
 		oldestTime := newestTime.Add(-duration)
@@ -77,6 +78,9 @@ func readAggregates(context appengine.Context,
 // HTTP handlers
 
 func getAggregates(writer http.ResponseWriter, request *http.Request) {
+	
+	log.Println("readAggregates request:", request)
+
 	context := appengine.NewContext(request)
 	encodedKey := mux.Vars(request)["board"]
 	boardKey, err := datastore.DecodeKey(encodedKey)

--- a/server/app.go
+++ b/server/app.go
@@ -8,6 +8,7 @@
 package performanceboard
 
 import (
+	"appengine"
 	"github.com/gorilla/mux"
 	"io/ioutil"
 	"net/http"

--- a/server/app.go
+++ b/server/app.go
@@ -15,7 +15,7 @@ import (
 
 var router *mux.Router
 
-func init() {
+func initRouter() *mux.Router {
 	router = mux.NewRouter()
 	router.HandleFunc("/api/post/{post_key}", getPost).Methods("GET").Name("get_post")
 	router.HandleFunc("/api/post", methodNotAllowed)
@@ -24,7 +24,7 @@ func init() {
 	router.HandleFunc("/api/{board}/{namespace}", getMetrics).Methods("GET").Name("namespace")
 	router.HandleFunc("/api/{board}/{namespace}", methodNotAllowed)
 	router.HandleFunc("/api/{board}", getNamespaces).Methods("GET").Name("board")
-	router.HandleFunc("/api/{board}", postMetric).Methods("POST")
+	router.HandleFunc("/api/{board}", handlePostMetric).Methods("POST")
 	router.HandleFunc("/api/{board}", handleClearBoard).Methods("PUT")
 	router.HandleFunc("/api/{board}", methodNotAllowed)
 	router.HandleFunc("/api/", handleCreateBoard).Methods("POST")
@@ -32,7 +32,12 @@ func init() {
 	router.HandleFunc("/api/", methodNotAllowed)
 	router.HandleFunc("/pbjs/{board}", servePBJS).Methods("GET")
 	router.HandleFunc("/{client:.*}", client).Name("client")
-	http.Handle("/", router)
+	return router
+}
+
+func init() {
+	router = initRouter()
+	http.Handle("/", initRouter())
 }
 
 var indexHtml, _ = ioutil.ReadFile("server/templates/index.html")

--- a/server/app.go
+++ b/server/app.go
@@ -25,10 +25,10 @@ func init() {
 	router.HandleFunc("/api/{board}/{namespace}", methodNotAllowed)
 	router.HandleFunc("/api/{board}", getNamespaces).Methods("GET").Name("board")
 	router.HandleFunc("/api/{board}", postMetric).Methods("POST")
-	router.HandleFunc("/api/{board}", clearBoard).Methods("PUT")
+	router.HandleFunc("/api/{board}", handleClearBoard).Methods("PUT")
 	router.HandleFunc("/api/{board}", methodNotAllowed)
-	router.HandleFunc("/api/", createBoard).Methods("POST")
-	router.HandleFunc("/api/", listBoards).Methods("GET")
+	router.HandleFunc("/api/", handleCreateBoard).Methods("POST")
+	router.HandleFunc("/api/", handleListBoards).Methods("GET")
 	router.HandleFunc("/api/", methodNotAllowed)
 	router.HandleFunc("/pbjs/{board}", servePBJS).Methods("GET")
 	router.HandleFunc("/{client:.*}", client).Name("client")
@@ -47,4 +47,19 @@ func client(writer http.ResponseWriter, request *http.Request) {
 
 func methodNotAllowed(writer http.ResponseWriter, request *http.Request) {
 	http.Error(writer, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+}
+
+func handleCreateBoard(writer http.ResponseWriter, request *http.Request) {
+	context := appengine.NewContext(request)
+	createBoard(context, writer, request)
+}
+
+func handleListBoards(writer http.ResponseWriter, request *http.Request) {
+	context := appengine.NewContext(request)
+	listBoards(context, writer, request)
+}
+
+func handleClearBoard(w http.ResponseWriter, r *http.Request) {
+	c := appengine.NewContext(r)
+	clearBoard(c, w, r)
 }

--- a/server/app.go
+++ b/server/app.go
@@ -8,7 +8,6 @@
 package performanceboard
 
 import (
-	"appengine"
 	"github.com/gorilla/mux"
 	"io/ioutil"
 	"net/http"
@@ -48,19 +47,4 @@ func client(writer http.ResponseWriter, request *http.Request) {
 
 func methodNotAllowed(writer http.ResponseWriter, request *http.Request) {
 	http.Error(writer, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
-}
-
-func handleCreateBoard(writer http.ResponseWriter, request *http.Request) {
-	context := appengine.NewContext(request)
-	createBoard(context, writer, request)
-}
-
-func handleListBoards(writer http.ResponseWriter, request *http.Request) {
-	context := appengine.NewContext(request)
-	listBoards(context, writer, request)
-}
-
-func handleClearBoard(w http.ResponseWriter, r *http.Request) {
-	c := appengine.NewContext(r)
-	clearBoard(c, w, r)
 }

--- a/server/board.go
+++ b/server/board.go
@@ -9,14 +9,6 @@ import (
 	"net/http"
 )
 
-const BoardKind = "Board"
-
-type Board struct {
-	Key    *datastore.Key `datastore:"-"`
-	Name   string
-	UserID string
-}
-
 func (board *Board) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 	api, _ := router.Get("board").URL("board", board.Key.Encode())
 	JsonResponse{
@@ -25,7 +17,8 @@ func (board *Board) ServeHTTP(writer http.ResponseWriter, request *http.Request)
 	}.Write(writer)
 }
 
-func createBoard(context appengine.Context, writer http.ResponseWriter, request *http.Request) {
+func handleCreateBoard(writer http.ResponseWriter, request *http.Request) {
+	context := appengine.NewContext(request)
 	boardName := request.FormValue("name")
 	board := Board{}
 	if u := user.Current(context); u != nil {
@@ -36,7 +29,8 @@ func createBoard(context appengine.Context, writer http.ResponseWriter, request 
 	board.ServeHTTP(writer, request)
 }
 
-func listBoards(context appengine.Context, writer http.ResponseWriter, request *http.Request) {
+func handleListBoards(writer http.ResponseWriter, request *http.Request) {
+	context := appengine.NewContext(request)
 	q := datastore.NewQuery(BoardKind).KeysOnly()
 	if keys, err := q.GetAll(context, nil); err != nil {
 		http.Error(writer, err.Error(), http.StatusInternalServerError)
@@ -58,7 +52,8 @@ func listBoards(context appengine.Context, writer http.ResponseWriter, request *
 	}
 }
 
-func clearBoard(c appengine.Context, w http.ResponseWriter, r *http.Request) {
+func handleClearBoard(w http.ResponseWriter, r *http.Request) {
+	c := appengine.NewContext(r)
 	keyString := mux.Vars(r)["board"]
 	key, err := datastore.DecodeKey(keyString)
 	if err != nil || key.Kind() != BoardKind {

--- a/server/board.go
+++ b/server/board.go
@@ -36,7 +36,6 @@ func handleListBoards(writer http.ResponseWriter, request *http.Request) {
 		http.Error(writer, err.Error(), http.StatusInternalServerError)
 	} else {
 		keyList := []JsonResponse{}
-		log.Println("keylist:", keyList)
 		for _, key := range keys {
 			api, _ := router.Get("client").URL("client", key.Encode())
 			log.Println("api:", api)
@@ -67,7 +66,7 @@ func handleClearBoard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	q := datastore.NewQuery(MetricKind).Ancestor(key).KeysOnly().Limit(2000)
+	q := datastore.NewQuery(MetricKind).Filter("BoardKey =", keyString).KeysOnly().Limit(2000)
 	for {
 		if keys, err := q.GetAll(c, nil); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/server/board_test.go
+++ b/server/board_test.go
@@ -5,7 +5,6 @@ import (
 	"appengine/aetest"
 	"appengine/datastore"
 	"encoding/json"
-	// "io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -19,7 +18,6 @@ type BoardResult struct {
 }
 
 func createTestBoard(c appengine.Context) (*httptest.ResponseRecorder, error) {
-
 	w := httptest.NewRecorder()
 	req, err := http.NewRequest("POST", "http://test.test/api/", nil)
 	if err != nil {
@@ -86,5 +84,5 @@ func TestListBoard(t *testing.T) {
 }
 
 func TestClearBoard(t *testing.T) {
-
+	t.Fatal()
 }

--- a/server/board_test.go
+++ b/server/board_test.go
@@ -1,0 +1,90 @@
+package performanceboard
+
+import (
+	"appengine"
+	"appengine/aetest"
+	"appengine/datastore"
+	"encoding/json"
+	// "io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type BoardResult struct {
+	Api   string `json:"api"`
+	Board string `json:"board"`
+}
+
+func createTestBoard(c appengine.Context) (*httptest.ResponseRecorder, error) {
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("POST", "http://test.test/api/", nil)
+	if err != nil {
+		return nil, err
+	}
+	createBoard(c, w, req)
+
+	// this block has a side effect of pushing data to disk
+	var result BoardResult
+	json.Unmarshal([]byte(w.Body.String()), &result)
+	fetchBoard(c, result.Board)
+
+	return w, nil
+}
+
+func fetchBoard(c appengine.Context, boardKey string) (*Board, error) {
+	key, _ := datastore.DecodeKey(boardKey)
+	board := Board{Key: key}
+	if err := datastore.Get(c, key, &board); err != nil {
+		return nil, err
+	}
+	return &board, nil
+}
+
+func TestCreateBoard(t *testing.T) {
+	c, _ := aetest.NewContext(nil)
+	w, _ := createTestBoard(c)
+
+	if w.Code != 200 {
+		t.Fatal("Expected code 200, recieved", w.Code)
+	}
+
+	var result BoardResult
+	json.Unmarshal([]byte(w.Body.String()), &result)
+
+	boardUrl := result.Api
+	boardKey := result.Board
+
+	if len(boardUrl) <= len(boardKey) || !strings.HasSuffix(boardUrl, boardKey) {
+		t.Fatal("board url has unexpected format:", boardUrl)
+	}
+}
+
+func TestListBoard(t *testing.T) {
+	c, _ := aetest.NewContext(nil)
+	createTestBoard(c)
+	createTestBoard(c)
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "http://test.test/api/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	listBoards(c, w, req)
+	t.Log(w.Body.String())
+
+	var results []BoardResult
+	err = json.Unmarshal([]byte(w.Body.String()), &results)
+	log.Println(results)
+	if len(results) != 2 {
+		t.Fatal("expected 2 board result")
+	}
+}
+
+func TestClearBoard(t *testing.T) {
+
+}

--- a/server/board_test.go
+++ b/server/board_test.go
@@ -5,7 +5,6 @@ import (
 	"appengine/aetest"
 	"appengine/datastore"
 	"encoding/json"
-	"log"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -24,13 +23,13 @@ func createTestBoard(inst aetest.Instance) (*httptest.ResponseRecorder, error) {
 		return nil, err
 	}
 
-	context := appengine.NewContext(req)
-
-	createBoard(context, w, req)
+	handleCreateBoard(w, req)
 
 	// this block has a side effect of pushing data to disk
 	var result BoardResult
 	json.Unmarshal([]byte(w.Body.String()), &result)
+
+	context := appengine.NewContext(req)
 	fetchBoard(context, result.Board)
 
 	return w, nil
@@ -81,9 +80,8 @@ func TestListBoard(t *testing.T) {
 	}
 
 	// make call
-	c := appengine.NewContext(req)
 	w := httptest.NewRecorder()
-	listBoards(c, w, req)
+	handleListBoards(w, req)
 
 	// define expected result structure
 	type BoardResultResponse struct {
@@ -99,5 +97,7 @@ func TestListBoard(t *testing.T) {
 }
 
 func TestClearBoard(t *testing.T) {
+	// TODO test setup requires posting Metrics to a Board (with Aggregation side-effects)
+	// TODO test that clearing board Removes All The Things
 	t.Fatal()
 }

--- a/server/digest.go
+++ b/server/digest.go
@@ -61,9 +61,8 @@ func storeMetric(context appengine.Context, boardKeyString string, postKey strin
 		}
 	}
 
-	// TODO restore aggregation when it is qualified with tests
 	// TODO optimize how often the aggregate chain is called to once per namespace per post
-	// aggregateSecond(context, metric.Start, boardKeyString, metric.Namespace)
+	aggregateSecond(context, metric.Start, boardKeyString, metric.Namespace)
 
 	return metric.Namespace, nil
 }
@@ -126,7 +125,6 @@ func aggregateSecond(context appengine.Context, t time.Time, boardKeyString stri
 
 func aggregateMore(context appengine.Context, t time.Time, boardKeyString string, namespace string, binType string) {
 	// Read the AggregateMetric table for a one-minute interval
-	boardKey, _ := datastore.DecodeKey(boardKeyString)
 	var aggregateBinType string
 	aggregateDuration := time.Minute
 	switch binType {
@@ -146,7 +144,7 @@ func aggregateMore(context appengine.Context, t time.Time, boardKeyString string
 
 	// readAggregates reads time backwards, so we jump time forward to read our duration
 	aggregateMetrics, _, err := readAggregates(
-		context, boardKey, namespace, aggregateBinType,
+		context, boardKeyString, namespace, aggregateBinType,
 		truncTime.Add(aggregateDuration), aggregateDuration, -1, "")
 
 	if err != nil {
@@ -175,7 +173,7 @@ func aggregateMore(context appengine.Context, t time.Time, boardKeyString string
 
 	// store values to AggregateMetric entity
 	keyID := fmt.Sprintf("%s:%s:%v:%s", boardKeyString, namespace, truncTime, binType)
-	key := datastore.NewKey(context, AggregateMetricKind, keyID, 0, boardKey)
+	key := datastore.NewKey(context, AggregateMetricKind, keyID, 0, nil)
 	aggMetric := AggregateMetric{
 		Key:       key,
 		BoardKey:  boardKeyString,

--- a/server/digest.go
+++ b/server/digest.go
@@ -63,7 +63,7 @@ func storeMetric(context appengine.Context, boardKeyString string, postKey strin
 
 	// TODO restore aggregation when it is qualified with tests
 	// TODO optimize how often the aggregate chain is called to once per namespace per post
-	//aggregateSecond(context, metric.Start, boardKeyString, metric.Namespace)
+	// aggregateSecond(context, metric.Start, boardKeyString, metric.Namespace)
 
 	return metric.Namespace, nil
 }
@@ -80,6 +80,7 @@ func aggregateSecond(context appengine.Context, t time.Time, boardKeyString stri
 	metrics, _, err := readMetrics(context, boardKeyString, namespace, truncTime, 1*time.Second, 0, -1, "")
 	count := len(metrics)
 	if count == 0 {
+		log.Println("no data to aggregate")
 		return
 	}
 
@@ -115,6 +116,7 @@ func aggregateSecond(context appengine.Context, t time.Time, boardKeyString stri
 		Count:     int64(count),
 	}
 	if _, err := datastore.Put(context, aggMetric.Key, &aggMetric); err != nil {
+		log.Println("Error on Metric Put:%v", err)
 		context.Errorf("Error on Metric Put:%v", err)
 		return
 	}

--- a/server/digest.go
+++ b/server/digest.go
@@ -126,7 +126,7 @@ func aggregateSecond(context appengine.Context, t time.Time, boardKeyString stri
 	}
 	// trim fractional second to bin aggregate computation
 	truncTime := t.Truncate(1 * time.Second)
-	metrics, _, err := readMetrics(context, boardKey, namespace, truncTime, 1*time.Second, 0, -1, "")
+	metrics, _, err := readMetrics(context, boardKeyString, namespace, truncTime, 1*time.Second, 0, -1, "")
 	count := len(metrics)
 	if count == 0 {
 		return
@@ -264,9 +264,8 @@ var digestPost = delay.Func("key", func(c appengine.Context, postKeyString strin
 	}
 
 	// enter the recursive storage routine
-	boardKeyString := postKey.Parent().Encode()
-	if namespace, err := storeMetric(c, boardKeyString, postKeyString, body, nil); err == nil {
-		storeTaxonomy(c, boardKeyString, "", namespace)
+	if namespace, err := storeMetric(c, post.BoardKey, postKeyString, body, nil); err == nil {
+		storeTaxonomy(c, post.BoardKey, "", namespace)
 	} else {
 		c.Errorf("Error storing Taxonomy:%v", err)
 	}

--- a/server/digest.go
+++ b/server/digest.go
@@ -9,57 +9,6 @@ import (
 	"time"
 )
 
-// data package parsing structure, not stored to disk.
-type PostBody struct {
-	Namespace string                 `json:"namespace"`
-	Start     time.Time              `json:"start"`
-	End       time.Time              `json:"end"`
-	Meta      map[string]interface{} `json:"meta"`
-	Children  []PostBody             `json:"children"`
-}
-
-// A Metric is a namespaced measurement. A metric's parent (for Ancestor queries)
-// is the metric that contained it in the origional Post. Therefore, a Metric
-// with the namespace 'X.Y.Z' will have an Ancestor Metric with a namespace
-// of 'X.Y'.
-const MetricKind = "Metric"
-
-type Metric struct {
-	Key       *datastore.Key `datastore:"-"`
-	Namespace string         // dot seperated name hierarchy
-	Meta      string         `datastore:",noindex"` // stringified JSON object
-	Start     time.Time      // UTC
-	End       time.Time      // UTC
-	Children  []Metric       `datastore:"-"`
-}
-
-// The Taxonomy table defines namespace relationships for fast lookup
-// Given static assignment of a namespace to a measurement on the client
-// this table should not continue to grow in size for repeated Posts.
-const TaxonomyKind = "Taxonomy"
-
-type Taxonomy struct {
-	Key        *datastore.Key `datastore:"-"`
-	BoardKey   string         // board this taxonomy is a member of
-	Namespace  string         // parent namespace, empty string for top-level namespaces
-	Childspace string         // a single child namespace of Namespace field
-}
-
-const AggregateMetricKind = "AggregateMetric"
-
-type AggregateMetric struct {
-	Key       *datastore.Key `datastore:"-"`
-	BoardKey  string
-	Namespace string
-	StartTime time.Time
-	BinType   string // second, minute, hour, day
-	Min       float64
-	Max       float64
-	Mean      float64
-	Sum       int64
-	Count     int64
-}
-
 func storeTaxonomy(context appengine.Context, boardKey string, parentNamespace string, childNamespace string) {
 	taxonomy := Taxonomy{}
 	keyID := fmt.Sprintf("%s:%s:%s", boardKey, parentNamespace, childNamespace)

--- a/server/metric.go
+++ b/server/metric.go
@@ -6,10 +6,10 @@ import (
 	"encoding/json"
 	"github.com/gorilla/mux"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"strconv"
 	"time"
-	"log"
 )
 
 const DEFAULT_LIMIT = 100

--- a/server/metric_test.go
+++ b/server/metric_test.go
@@ -1,1 +1,78 @@
 package performanceboard
+
+import (
+	"appengine"
+	"appengine/aetest"
+	"bytes"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestPostMetric(t *testing.T) {
+	inst, err := aetest.NewInstance(&aetest.Options{StronglyConsistentDatastore: true})
+	defer inst.Close()
+
+	// setup preconditions
+	response, err := createTestBoard(inst)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var result BoardResult
+	json.Unmarshal([]byte(response.Body.String()), &result)
+
+	boardKeyString := result.Board
+	t.Log("boardKeyString:", boardKeyString)
+
+	body := `{
+        "start":"1994-11-05T13:15:30Z",
+        "end":"1994-11-05T13:15:31Z",
+        "meta":{"meta":"data"},
+        "namespace":"test"
+        }`
+
+	// define call under test
+	req, err := inst.NewRequest("POST",
+		"http://www.test.com/api/"+boardKeyString,
+		bytes.NewBuffer([]byte(body)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// make call
+	w := httptest.NewRecorder()
+	r := initRouter() // enables parsing route parameters
+	r.ServeHTTP(w, req)
+
+
+	postBody := PostBody{}
+	if err := json.Unmarshal([]byte(body), &postBody); err != nil {
+		t.Fatal(err)
+	}
+
+	// assert the call created an entity
+	context := appengine.NewContext(req)
+	metrics, cursor, err := readMetrics(
+		context,
+		boardKeyString,
+		"test",        // namespace
+		postBody.End,  // newestTime (rev chron order)
+		3 * time.Second, // duration
+		0,             // depth
+		100,           // limit
+		"")            // cursor
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(metrics) < 1 {
+		t.Fatal("no metrics stored")
+	}
+	if metrics[0].Namespace != "test" {
+		t.Fatal("error reading metric")
+	}
+	if cursor != "" {
+		t.Fatal("non-empty cursor recieved")
+	}
+}

--- a/server/metric_test.go
+++ b/server/metric_test.go
@@ -1,0 +1,1 @@
+package performanceboard

--- a/server/metric_test.go
+++ b/server/metric_test.go
@@ -41,28 +41,30 @@ func TestPostMetric(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// make call
+	// make the call
 	w := httptest.NewRecorder()
 	r := initRouter() // enables parsing route parameters
 	r.ServeHTTP(w, req)
 
-
+	// cheat creating the query time parsing it from the test data
 	postBody := PostBody{}
 	if err := json.Unmarshal([]byte(body), &postBody); err != nil {
 		t.Fatal(err)
 	}
 
-	// assert the call created an entity
+	// query for data
 	context := appengine.NewContext(req)
 	metrics, cursor, err := readMetrics(
 		context,
 		boardKeyString,
 		"test",        // namespace
 		postBody.End,  // newestTime (rev chron order)
-		3 * time.Second, // duration
+		3*time.Second, // duration
 		0,             // depth
 		100,           // limit
 		"")            // cursor
+
+	// make assertions!
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,4 +77,6 @@ func TestPostMetric(t *testing.T) {
 	if cursor != "" {
 		t.Fatal("non-empty cursor recieved")
 	}
+
+	// TODO query for aggregate data
 }

--- a/server/metric_test.go
+++ b/server/metric_test.go
@@ -78,5 +78,24 @@ func TestPostMetric(t *testing.T) {
 		t.Fatal("non-empty cursor recieved")
 	}
 
-	// TODO query for aggregate data
+	// query for aggregate data
+	aggMetrics, cursor, err := readAggregates(context,
+		boardKeyString,
+		"test",
+		"second",
+		postBody.End,
+		3*time.Second,
+		100,
+		"")
+
+	// make assertions!
+	if len(aggMetrics) < 1 {
+		t.Fatal("no aggregregate metrics found")
+	}
+	if aggMetrics[0].Namespace != "test" {
+		t.Fatal("unexpected Namespace", aggMetrics[0].Namespace)
+	}
+	if cursor != "" {
+		t.Fatal("unexpected cursor from readAggregates")
+	}
 }

--- a/server/models.go
+++ b/server/models.go
@@ -1,0 +1,79 @@
+package performanceboard
+
+import (
+	"appengine/datastore"
+	"time"
+)
+
+// Board is the root structure for data. All data is posted against a board
+const BoardKind = "Board"
+
+type Board struct {
+	Key    *datastore.Key `datastore:"-"`
+	Name   string
+	UserID string
+}
+
+// data package parsing structure, not stored to disk.
+// it represents a metric
+type PostBody struct {
+	Namespace string                 `json:"namespace"`
+	Start     time.Time              `json:"start"`
+	End       time.Time              `json:"end"`
+	Meta      map[string]interface{} `json:"meta"`
+	Children  []PostBody             `json:"children"`
+}
+
+// A Post entity preserves a PostBody to datastore.
+const PostKind = "Post"
+
+type Post struct {
+	Key       *datastore.Key `datastore:"-"`
+	BoardKey  string         `datastore:",index"`
+	Body      string         `datastore:",noindex"`
+	Timestamp time.Time      `datastore:",noindex"`
+}
+
+// A Metric is a namespaced measurement. A metric's parent (for Ancestor queries)
+// is the metric that contained it in the origional Post. Therefore, a Metric
+// with the namespace 'X.Y.Z' will have an Ancestor Metric with a namespace
+// of 'X.Y'.
+const MetricKind = "Metric"
+
+type Metric struct {
+	Key       *datastore.Key `datastore:"-"`
+	Namespace string         // dot seperated name hierarchy
+	Meta      string         `datastore:",noindex"` // stringified JSON object
+	Start     time.Time      // UTC
+	End       time.Time      // UTC
+	Children  []Metric       `datastore:"-"`
+}
+
+// The Taxonomy table defines namespace relationships for fast lookup
+// Given static assignment of a namespace to a measurement on the client
+// this table should not continue to grow in size for repeated Posts.
+const TaxonomyKind = "Taxonomy"
+
+type Taxonomy struct {
+	Key        *datastore.Key `datastore:"-"`
+	BoardKey   string         // board this taxonomy is a member of
+	Namespace  string         // parent namespace, empty string for top-level namespaces
+	Childspace string         // a single child namespace of Namespace field
+}
+
+// AggregateMetric is a computed entity that captures the value of multiple
+// Metric entities over an interval of time.
+const AggregateMetricKind = "AggregateMetric"
+
+type AggregateMetric struct {
+	Key       *datastore.Key `datastore:"-"`
+	BoardKey  string
+	Namespace string
+	StartTime time.Time
+	BinType   string // second, minute, hour, day
+	Min       float64
+	Max       float64
+	Mean      float64
+	Sum       int64
+	Count     int64
+}

--- a/server/models.go
+++ b/server/models.go
@@ -42,6 +42,8 @@ const MetricKind = "Metric"
 
 type Metric struct {
 	Key       *datastore.Key `datastore:"-"`
+	BoardKey  string         // top-level membership
+	ParentKey string         // key of enclosing Metric
 	Namespace string         // dot seperated name hierarchy
 	Meta      string         `datastore:",noindex"` // stringified JSON object
 	Start     time.Time      // UTC

--- a/server/models.go
+++ b/server/models.go
@@ -34,10 +34,9 @@ type Post struct {
 	Timestamp time.Time      `datastore:",noindex"`
 }
 
-// A Metric is a namespaced measurement. A metric's parent (for Ancestor queries)
-// is the metric that contained it in the origional Post. Therefore, a Metric
-// with the namespace 'X.Y.Z' will have an Ancestor Metric with a namespace
-// of 'X.Y'.
+// A Metric is a namespaced measurement. A metric's parent  is the metric
+// that contained it in the origional Post. Therefore, a Metric with the
+// namespace 'X.Y.Z' will have an Parent Metric with a namespace of 'X.Y'.
 const MetricKind = "Metric"
 
 type Metric struct {

--- a/server/post.go
+++ b/server/post.go
@@ -12,6 +12,7 @@ const PostKind = "Post"
 
 type Post struct {
 	Key       *datastore.Key `datastore:"-"`
+	BoardKey  string         `datastore:",index"`
 	Body      string         `datastore:",noindex"`
 	Timestamp time.Time      `datastore:",noindex"`
 }

--- a/server/post.go
+++ b/server/post.go
@@ -5,17 +5,7 @@ import (
 	"appengine/datastore"
 	"github.com/gorilla/mux"
 	"net/http"
-	"time"
 )
-
-const PostKind = "Post"
-
-type Post struct {
-	Key       *datastore.Key `datastore:"-"`
-	BoardKey  string         `datastore:",index"`
-	Body      string         `datastore:",noindex"`
-	Timestamp time.Time      `datastore:",noindex"`
-}
 
 func getPost(writer http.ResponseWriter, request *http.Request) {
 	context := appengine.NewContext(request)


### PR DESCRIPTION
This PR is about removing the Ancestor relationships that were discovered to have a dramatic effect on performance because Datastore enforces group consistency in such a way that write complexity increases linearly with the size of a family group.

WIP; TODOs:
- [ ] Test board cleanup
- [ ] Test taxonomy endpoint
